### PR TITLE
Auto remove servers after time

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,16 +157,18 @@ public class NodeListServerListResponse
 [Serializable]
 public class NodeListServerListEntry
 {
+    // The secret key stored on the master server config.ini
+    public string serverKey;
     // IP address. Beware: Might be IPv6 format, and require you to chop off the leading "::ffff:" part. YMMV.
     public string ip;
     // Name of the server.
-    public string name;
+    public string serverName;
     // Port of the server.
-    public int port;
+    public int serverPort;
     // Number of players on the server.
-    public int players;
+    public int serverPlayers;
     // The number of players maximum allowed on the server.
-    public int capacity;
+    public int serverCapacity;
     // Extra data.
     public string extras;
 }

--- a/listServer.js
+++ b/listServer.js
@@ -248,28 +248,26 @@ function apiUpdateServerInList(req, res) {
 
 	// TODO: Improve this. This feels ugly hack tier and I feel it could be more elegant.
 	// If anyone has a PR to improves this, please send me a PR.
-	var serverInQuestion = knownServers.filter((server) => (server.uuid === req.body.serverUuid));
+	var serverInQuestion = knownServers.filter((server) => (server.uuid === req.body.serverUuid))[0];
 	var notTheServerInQuestion = knownServers.filter((server) => (server.uuid !== req.body.serverUuid));
 
-	// I hate it when we get arrays back from that filter function...
-	// Pretty sure this could be improved. PR welcome.
 	var updatedServer = [];
-	updatedServer["uuid"] = serverInQuestion[0].uuid;
-	updatedServer["ip"] = serverInQuestion[0].ip;
+	updatedServer["uuid"] = serverInQuestion.uuid;
+	updatedServer["ip"] = serverInQuestion.ip;
 	
-	updatedServer["port"] = serverInQuestion[0].port;
-	updatedServer["capacity"] = serverInQuestion[0].capacity;
+	updatedServer["port"] = serverInQuestion.port;
+	updatedServer["capacity"] = serverInQuestion.capacity;
 
 	if(typeof req.body.serverExtras !== "undefined") {
 		updatedServer["extras"] = req.body.serverExtras.trim();
 	} else {
-		updatedServer["extras"] = serverInQuestion[0].extras;
+		updatedServer["extras"] = serverInQuestion.extras;
 	}
 
 	if(typeof req.body.serverName !== "undefined") {
 		updatedServer["name"] = req.body.serverName.trim();
 	} else {
-		updatedServer["name"] = serverInQuestion[0].name;
+		updatedServer["name"] = serverInQuestion.name;
 	}
 
 	if(typeof req.body.serverPlayers !== "undefined") {
@@ -279,7 +277,7 @@ function apiUpdateServerInList(req, res) {
 			updatedServer["players"] = parseInt(req.body.serverPlayers, 10);
 		}
 	} else {
-		updatedServer["players"] = serverInQuestion[0].players;
+		updatedServer["players"] = serverInQuestion.players;
 	}
 	
 	// Server capacity might have changed, let's update that if needed
@@ -433,7 +431,6 @@ expressApp.get("/", denyRequest);
 expressApp.post("/list", apiGetServerList);
 expressApp.post("/add", apiAddToServerList);
 expressApp.post("/remove", apiRemoveFromServerList);
-expressApp.post("/update", apiUpdateServerInList);
 
 // Finally, start the application
 console.log("Welcome to NodeListServer Generation 2 Revision 2");

--- a/listServer.js
+++ b/listServer.js
@@ -429,7 +429,7 @@ function apiRemoveFromServerList(req, res) {
 
 // Automatically remove servers when they haven't updated after the time specified in the config.ini
 async function removeOldServers() {
-	var oldServers = knownServers.filter((freshServer) => (freshServer.lastUpdated <= Date.now()));
+	knownServers = knownServers.filter((freshServer) => (freshServer.lastUpdated >= Date.now()));
     setTimeout(removeOldServers, configuration.Pruning.inactiveServerRemovalMinutes * 60 * 1000);
 }
 

--- a/listServer.js
+++ b/listServer.js
@@ -327,10 +327,7 @@ function apiAddToServerList(req, res) {
 	}
 
 	
-	if(apiDoesServerExistByName(req.body.serverName)) {
-		loggerInstance.warn(`Server name already exists ${req.body.serverName}'.`);
-		return res.sendStatus(400);
-	}
+
 	
 	// Add the server to the list.
 	
@@ -344,6 +341,11 @@ function apiAddToServerList(req, res) {
 	}
 	else
 	{
+		if(apiDoesServerExistByName(req.body.serverName)) {
+			loggerInstance.warn(`Server name already exists ${req.body.serverName}'.`);
+			return res.sendStatus(400);
+		}
+		
 		// Checkpoint 2: IP and Port collision check
 		// If there's already a server on this IP or Port then don't add the server to the cache. This will stop duplicates.
 		if(apiDoesThisServerExistByAddressPort(req.ip, req.body.serverPort)) {

--- a/listServer.js
+++ b/listServer.js
@@ -325,6 +325,12 @@ function apiAddToServerList(req, res) {
 		loggerInstance.warn(`Request from ${req.ip} denied: Port was out of bounds.`);
 		return res.sendStatus(400);
 	}
+
+	
+	if(apiDoesServerExistByName(req.body.serverName)) {
+		loggerInstance.warn(`Server name already exists ${req.body.serverName}'.`);
+		return res.sendStatus(400);
+	}
 	
 	// Add the server to the list.
 	
@@ -343,11 +349,6 @@ function apiAddToServerList(req, res) {
 		if(apiDoesThisServerExistByAddressPort(req.ip, req.body.serverPort)) {
 			// Collision - abort!
 			loggerInstance.warn(`Server IP and Port collision check failed for ${req.ip}'.`);
-			return res.sendStatus(400);
-		}
-
-		if(apiDoesServerExistByName(req.body.serverName)) {
-			loggerInstance.warn(`Server name already exists ${req.body.serverName}'.`);
 			return res.sendStatus(400);
 		}
 

--- a/listServer.js
+++ b/listServer.js
@@ -427,9 +427,9 @@ function apiRemoveFromServerList(req, res) {
 	}
 }
 
+// Automatically remove servers when they haven't updated after the time specified in the config.ini
 async function removeOldServers() {
 	var oldServers = knownServers.filter((freshServer) => (freshServer.lastUpdated <= Date.now()));
-    console.log(oldServers.length);
     setTimeout(removeOldServers, configuration.Pruning.inactiveServerRemovalMinutes * 60 * 1000);
 }
 

--- a/listServer.js
+++ b/listServer.js
@@ -425,6 +425,15 @@ function apiRemoveFromServerList(req, res) {
 	}
 }
 
+async function removeOldServers() {
+	var oldServers = knownServers.filter((freshServer) => (freshServer.lastUpdated <= Date.now()));
+    console.log(oldServers.length);
+    setTimeout(removeOldServers, configuration.Pruning.inactiveServerRemovalMinutes * 60 * 1000);
+}
+
+removeOldServers();
+
+
 // -- Start the application -- //
 // Coburn: Moved the actual startup routines here to help boost Codacy's opinion.
 // Callbacks to various functions, leave this alone unless you know what you're doing.

--- a/listServer.js
+++ b/listServer.js
@@ -344,7 +344,12 @@ function apiAddToServerList(req, res) {
 		// If there's already a server on this IP or Port then don't add the server to the cache. This will stop duplicates.
 		if(apiDoesThisServerExistByAddressPort(req.ip, req.body.serverPort)) {
 			// Collision - abort!
-			loggerInstance.warn(`Server IP and Port collision check failed for ${req.ip} with UUID '${req.body.serverUuid}'.`);
+			loggerInstance.warn(`Server IP and Port collision check failed for ${req.ip}'.`);
+			return res.sendStatus(400);
+		}
+
+		if(apiDoesServerExistByName(req.body.serverName)) {
+			loggerInstance.warn(`Server name already exists ${req.body.serverName}'.`);
 			return res.sendStatus(400);
 		}
 

--- a/listServer.js
+++ b/listServer.js
@@ -387,7 +387,7 @@ function apiAddToServerList(req, res) {
 		knownServers.push(newServer);
 
 		loggerInstance.info(`New server added: '${req.body.serverName}' from ${req.ip}. UUID: '${newUuid}'`);
-		return res.send("OK\n");
+		return res.send(newUuid);
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,9 +144,9 @@
       }
     },
     "express-rate-limit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.0.0.tgz",
-      "integrity": "sha512-dhT57wqxfqmkOi4HM7NuT4Gd7gbUgSK2ocG27Y6lwm8lbOAw9XQfeANawGq8wLDtlGPO1ZgDj0HmKsykTxfFAg=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.3.0.tgz",
+      "integrity": "sha512-qJhfEgCnmteSeZAeuOKQ2WEIFTX5ajrzE0xS6gCOBCoRQcU+xEzQmgYQQTpzCcqUAAzTEtu4YEih4pnLfvNtew=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -163,9 +163,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -188,9 +188,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "http-errors": {
       "version": "1.7.2",
@@ -236,23 +236,23 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log4js": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.1.2.tgz",
-      "integrity": "sha512-knS4Y30pC1e0n7rfx3VxcLOdBCsEo0o6/C7PVTGxdVK+5b1TYOSGQPn9FDcrhkoQBV29qwmA2mtkznPAQKnxQg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
       "requires": {
         "date-format": "^3.0.0",
         "debug": "^4.1.1",
         "flatted": "^2.0.1",
         "rfdc": "^1.1.4",
-        "streamroller": "^2.2.3"
+        "streamroller": "^2.2.4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -362,9 +362,9 @@
       }
     },
     "rfdc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -425,9 +425,9 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "streamroller": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
-      "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",
@@ -440,11 +440,11 @@
           "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -482,6 +482,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "express-rate-limit": "^5.0.0",
-    "log4js": "^6.1.2",
-    "multi-ini": "^2.1.2"
+    "express-rate-limit": "^5.3.0",
+    "log4js": "^6.3.0",
+    "multi-ini": "^2.1.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This uses an async function with setTimeout to automatically remove old servers after the timeout specified in config.ini

This is useful when the game server crashes, comes back online, and attempts to re-add itself to the master server before a player is able to call /list.

Before this was added, the server would never be able to add itself to the master server unless it called /list because the master server would give an error about a conflicting IP. This still happens until the master server automatically prunes old servers but once that happens, the game server will get added and will be shown to the player the next time they call /list

Probably not everyone will need this but the branch exists on my fork for anyone who does if this PR isnt merged.