### PR TITLE
Remove UUID from /list response

### DIFF
--- a/listServer.js
+++ b/listServer.js
@@ -221,7 +221,6 @@ function apiGetServerList(req, res) {
 		}
 
 		serverList.push({ 
-			"uuid": knownServer.uuid,
 			"ip": knownServer.ip, 
 			"name": knownServer.name, 
 			"port": parseInt(knownServer.port, 10), 


### PR DESCRIPTION
This fixes a vulnerability where calling /list was including the UUID of the servers. With a UUID, it is possible to modify any server values to whatever you wish. 

This PR removes UUID from the list response.