### PR TITLE
Fix bug with how IP is used when adding a new server

### DIFF
--- a/listServer.js
+++ b/listServer.js
@@ -358,7 +358,7 @@ function apiAddToServerList(req, res) {
 		// We'll get the IP address directly, don't worry about that
 		var newServer = { 
 			"uuid": newUuid, 
-			"ip": req.ip, 
+			"ip": req.body.ip, 
 			"name": req.body.serverName, 
 			"port": parseInt(req.body.serverPort, 10),
 			"lastUpdated": (Date.now() + (configuration.Pruning.inactiveServerRemovalMinutes * 60 * 1000))


### PR DESCRIPTION
This PR fixes a bug where the IP provided in the request body of the /add endpoint was not being used at all. 