### PR TITLE
Fixed NLS making its own UUID, and not using sent.

### DIFF
--- a/listServer.js
+++ b/listServer.js
@@ -352,7 +352,7 @@ function apiAddToServerList(req, res) {
 			return res.sendStatus(400);
 		}
 
-		var newUuid= req.body.serverUuid;
+		var newUuid = req.body.serverUuid;
 		//var newUuid = generateUuid();
 
 		// We'll get the IP address directly, don't worry about that

--- a/listServer.js
+++ b/listServer.js
@@ -352,7 +352,8 @@ function apiAddToServerList(req, res) {
 			return res.sendStatus(400);
 		}
 
-		var newUuid = generateUuid();
+		var newUuid= req.body.serverUuid;
+		//var newUuid = generateUuid();
 
 		// We'll get the IP address directly, don't worry about that
 		var newServer = { 


### PR DESCRIPTION
Adding new server, was creating a UUID, and not using the one sent.
Causing a mismatch with removal or update request of server.

But lets discuss this if needed, why is there a generateUuid function? And why was it not using clients sent uuid?
(Edit: Sounds like this is for a new feature, thats currently not used in Gen 2 NLS, fix is still needed IMO)