### PR TITLE
Request handler fix! (Important)

### DIFF
--- a/lib/requestHandlers.js
+++ b/lib/requestHandlers.js
@@ -4,7 +4,8 @@ const { configuration } = require("./config");
 
 // Our gatekeeper: Any request must pass it's tests before being allowed to continue.
 function handleAllRequests(req, res, next) {
-  if (!["/list", "/add", "/remove"].includes(req.path)) res.status(401).send("Unauthorized");
+  if (!["/list", "/add", "/remove"].some((path) => req.path.includes(path)))
+    return res.status(401).send("Unauthorized");
 
   if (!req.body.serverKey || req.body.serverKey !== configuration.Auth.communicationKey)
     return res.status(403).send("Forbidden");


### PR DESCRIPTION
Request handler was previously checking if the user's current path was part of the array, instead of whether any of the elements in the array were part of the user's current path. Also added a `return` to avoid sending more than 1 status which caused server to crash.

